### PR TITLE
Avoid 2 Xcode errors and "view is not in the window hierarchy error on iOS8"

### DIFF
--- a/RateMyApp.swift
+++ b/RateMyApp.swift
@@ -45,11 +45,11 @@ class RateMyApp : UIViewController,UIAlertViewDelegate{
     var promptAfterCustomEventsCount = 10
     var daysBeforeReminding:Double = 1
     
-    var alertTitle = "Rate my app"
+    var alertTitle = NSLocalizedString("Rate the app", comment: "RateMyApp")
     var alertMessage = ""
-    var alertOKTitle = "Rate it now"
-    var alertCancelTitle = "Don't bother me again"
-    var alertRemindLaterTitle = "Remind me later"
+    var alertOKTitle = NSLocalizedString("Rate it now", comment: "RateMyApp")
+    var alertCancelTitle = NSLocalizedString("Don't bother me again", comment: "RateMyApp")
+    var alertRemindLaterTitle = NSLocalizedString("Remind me later", comment: "RateMyApp")
     var appID = ""
     
     


### PR DESCRIPTION
Hi,
I'm not sure about this fix (and I'm new with Swift), it could be better to add a public property "receiverController" to RateMyApp class. This controller could be set before call the "trackAppUsage".
In all case, I think this fallback is required.

Let me know.
- [ ] 2 Xcode errors
- [ ] view is not in the window hierarchy error on iOS8
- [ ] Usage of NSLocalizedString

++
