### PR TITLE
fix the remind later date problem

### DIFF
--- a/RateMyApp.swift
+++ b/RateMyApp.swift
@@ -175,7 +175,7 @@ class RateMyApp : UIViewController,UIAlertViewDelegate{
         
         if(hasChosenRemindLater)
         {
-            let remindLaterDate = prefs.objectForKey(kFirstUseDate) as! NSDate
+            let remindLaterDate = prefs.objectForKey(kRemindLaterPressedDate) as! NSDate
             
             let timeInterval = NSDate().timeIntervalSinceDate(remindLaterDate)
             


### PR DESCRIPTION
the original version used first app use time as the reference date to decide a remind later pop time. I guess the reference should be the date you pressed the remind me later button. I tested this and is satisfied with this change.